### PR TITLE
Auto run registry entry missing quotes around path #233

### DIFF
--- a/src/HASS.Agent/Managers/LaunchManager.cs
+++ b/src/HASS.Agent/Managers/LaunchManager.cs
@@ -21,7 +21,7 @@ namespace HASS.Agent.Managers
                 var val = (string)key?.GetValue(Variables.ApplicationName, string.Empty);
                 if (string.IsNullOrWhiteSpace(val)) return false;
 
-                return val == Variables.ApplicationExecutable;
+                return val == $"\"{Variables.ApplicationExecutable}\"";
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Add quotes when checking if value is set.

Not sure this is the most elegant way of doing this, I thought about changing ApplicationExecutable to include quotes but that looked like it might have a bigger impact.