### PR TITLE
Update Languages.de.resx

### DIFF
--- a/src/HASS.Agent/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent/Resources/Localization/Languages.de.resx
@@ -2632,7 +2632,7 @@ Dies ist eine ressourcenbelastende Aufgabe, daher beträgt das empfohlene Interv
     <value>Laden</value>
   </data>
   <data name="ComponentStatus_Ok" xml:space="preserve">
-    <value>Durchführung</value>
+    <value>Läuft</value>
   </data>
   <data name="ComponentStatus_Stopped" xml:space="preserve">
     <value>Gestoppt</value>


### PR DESCRIPTION
German Translation of the 'Running state' replaced from "Durchführung" (what makes no sense in this context) to "Läuft" (process is running/active).